### PR TITLE
Added user name for events under tasks instead of event_owner id

### DIFF
--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -158,6 +158,7 @@ router.get('/userProfile', withAuth, async (req, res) => {
           'event_address_state',
           'event_address_zip',
          ],
+
         },
         {
           model: Task,
@@ -179,10 +180,21 @@ router.get('/userProfile', withAuth, async (req, res) => {
                 'event_address_state',
                 'event_address_zip',
               ],
-            }
-          ]
-        }
-      ]
+
+            include: [
+              {
+                model: User,
+                attributes: [
+                  'id',
+                  'first_name',
+                  'last_name'
+                ],
+               },
+            ],
+            },
+          ],
+        },
+      ],
     });
 
     // Serialize data so the template can read it

--- a/views/userProfile.handlebars
+++ b/views/userProfile.handlebars
@@ -82,7 +82,7 @@
                   <tr>
                     <td scope="row">{{task.event.id}}</td>
                     <td>{{task.event.event_name}}</td>
-                    <td>{{task.event.event_owner}}</td>
+                    <td>{{task.event.user.first_name}} {{task.event.user.last_name}}</td>
                     <td>{{task.name}}</td>
                     <td>
                       <i class="fa fa-pencil" aria-hidden="true"></i>


### PR DESCRIPTION
Hi, I added the event owner's name instead of id to the userProfile page.  I didn't realize the previous pull request was already merged.